### PR TITLE
docs(readme): replace gtramontina with ghooks-org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # ghooks
 
 [![version](https://img.shields.io/npm/v/ghooks.svg?style=flat-square)](http://npm.im/ghooks)
-[![travis build](https://img.shields.io/travis/gtramontina/ghooks.svg?style=flat-square)](https://travis-ci.org/gtramontina/ghooks)
+[![travis build](https://img.shields.io/travis/ghooks-org/ghooks.svg?style=flat-square)](https://travis-ci.org/ghooks-org/ghooks)
 [![AppVeyor](https://img.shields.io/appveyor/ci/gtramontina/ghooks.svg?style=flat-square)](https://ci.appveyor.com/project/gtramontina/ghooks)
-[![codecov coverage](https://img.shields.io/codecov/c/github/gtramontina/ghooks.svg?style=flat-square)](https://codecov.io/github/gtramontina/ghooks)
-[![Dependencies status](https://img.shields.io/david/gtramontina/ghooks.svg?style=flat-square)](https://david-dm.org/gtramontina/ghooks#info=dependencies)
-[![Dev Dependencies status](https://img.shields.io/david/dev/gtramontina/ghooks.svg?style=flat-square)](https://david-dm.org/gtramontina/ghooks#info=devDependencies)
+[![codecov coverage](https://img.shields.io/codecov/c/github/ghooks-org/ghooks.svg?style=flat-square)](https://codecov.io/github/ghooks-org/ghooks)
+[![Dependencies status](https://img.shields.io/david/ghooks-org/ghooks.svg?style=flat-square)](https://david-dm.org/ghooks-org/ghooks#info=dependencies)
+[![Dev Dependencies status](https://img.shields.io/david/dev/ghooks-org/ghooks.svg?style=flat-square)](https://david-dm.org/ghooks-org/ghooks#info=devDependencies)
 
 [![MIT License](https://img.shields.io/npm/l/ghooks.svg?style=flat-square)](http://opensource.org/licenses/MIT)
 [![downloads](https://img.shields.io/npm/dm/ghooks.svg?style=flat-square)](http://npm-stat.com/charts.html?package=ghooks&from=2014-04-01)
@@ -77,14 +77,14 @@ One of the last things you want is to raise the barrier to contributing to your 
 
 ## Common Issues
 
-* [Usage with git GUI clients](https://github.com/gtramontina/ghooks/issues/18) – Thanks to [@JamieMason](https://github.com/JamieMason)
+* [Usage with git GUI clients](https://github.com/ghooks-org/ghooks/issues/18) – Thanks to [@JamieMason](https://github.com/JamieMason)
 
 ## Credits
 This module is heavily inspired by [__@nlf__](https://github.com/nlf)'s [precommit-hook](https://www.npmjs.org/package/precommit-hook)
 
 ## Contributors
 
-Huge thanks to everyone listed [here](https://github.com/gtramontina/ghooks/graphs/contributors)!
+Huge thanks to everyone listed [here](https://github.com/ghooks-org/ghooks/graphs/contributors)!
 
 ## License
 


### PR DESCRIPTION
This is so we get the badges working again (have to re-enable them for the new repository path).