### PR TITLE
Relative Path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage
 .idea
 .opt-in
 .opt-out
+package-lock.json

--- a/lib/hook.template.raw
+++ b/lib/hook.template.raw
@@ -4,7 +4,7 @@
 const fs = require('fs')
 const path = require('path')
 
-const nodeModulesPath = '{{node_modules_path}}'
+const nodeModulesPath = getNodeModulesAbsoluteEntryPoint()
 const ghooks = getGhooksEntryPoint()
 
 if (checkForGHooks(ghooks)) {
@@ -17,6 +17,14 @@ function getGhooksEntryPoint() {
     return 'ghooks'
   } catch (e) {
     return getGhooksAbsoluteEntryPoint()
+  }
+}
+
+function getNodeModulesAbsoluteEntryPoint() {
+  try {
+    return path.resolve(__dirname, '../', '../', 'node_modules')
+  } catch (e) {
+    return '{{node_modules_path}}'
   }
 }
 

--- a/test/hook.template.raw.test.js
+++ b/test/hook.template.raw.test.js
@@ -1,3 +1,4 @@
+const path = require('path')
 require('./setup')()
 
 describe('hook.template.raw', function describeHookTemplateRaw() {
@@ -11,7 +12,28 @@ describe('hook.template.raw', function describeHookTemplateRaw() {
 
     it('delegates the hook execution to ghooks', () => {
       const filename = path.resolve(process.cwd(), 'lib', 'hook.template.raw')
-      expect(this.ghooks).to.have.been.calledWith('{{node_modules_path}}', filename)
+      const calledWith = path.resolve(__dirname, '../', '../', 'node_modules')
+      expect(this.ghooks).to.have.been.calledWith(calledWith, filename)
+    })
+
+    it('works when node modules cannot be found', () => {
+      const ghooks = sinon.stub()
+      let throwException = true
+      proxyquire('../lib/hook.template.raw', {
+        ghooks,
+        path: {
+          resolve: () => {
+            if (throwException) {
+              throwException = false
+              throw new Error('path missing')
+            }
+            return '{{node_modules_path}}'
+          },
+        },
+      })
+
+      const filename = path.resolve(process.cwd(), 'lib', 'hook.template.raw')
+      expect(ghooks).to.have.been.calledWith('{{node_modules_path}}', filename)
     })
 
   })
@@ -28,14 +50,15 @@ describe('hook.template.raw', function describeHookTemplateRaw() {
   describe('when ghooks is installed, but the node working dir is below the project dir', () => {
 
     beforeEach(() => {
-      const ghooksEntryPoint = path.resolve(__dirname, '..', '{{node_modules_path}}', 'ghooks')
+      const ghooksEntryPoint = path.resolve(__dirname, '../', '../', 'node_modules', 'ghooks')
       this.ghooks = sinon.stub()
       proxyquire('../lib/hook.template.raw', {ghooks: null, [ghooksEntryPoint]: this.ghooks})
     })
 
     it('delegates the hook execution to ghooks', () => {
       const filename = path.resolve(process.cwd(), 'lib', 'hook.template.raw')
-      expect(this.ghooks).to.have.been.calledWith('{{node_modules_path}}', filename)
+      const calledWith = path.resolve(__dirname, '../', '../', 'node_modules')
+      expect(this.ghooks).to.have.been.calledWith(calledWith, filename)
     })
 
   })
@@ -60,7 +83,8 @@ describe('hook.template.raw', function describeHookTemplateRaw() {
 
     it('delegates the hook execution to ghooks', () => {
       const filename = path.resolve(process.cwd(), 'lib', 'hook.template.raw')
-      expect(this.ghooks).to.have.been.calledWith('{{node_modules_path}}', filename)
+      const calledWith = path.resolve(__dirname, '../', '../', 'node_modules')
+      expect(this.ghooks).to.have.been.calledWith(calledWith, filename)
     })
 
   })

--- a/test/hook.template.raw.test.js
+++ b/test/hook.template.raw.test.js
@@ -18,13 +18,13 @@ describe('hook.template.raw', function describeHookTemplateRaw() {
 
     it('works when node modules cannot be found', () => {
       const ghooks = sinon.stub()
-      let throwException = true
+      this.throwException = true
       proxyquire('../lib/hook.template.raw', {
         ghooks,
         path: {
           resolve: () => {
-            if (throwException) {
-              throwException = false
+            if (this.throwException) {
+              this.throwException = false
               throw new Error('path missing')
             }
             return '{{node_modules_path}}'


### PR DESCRIPTION
Hooks break when the path changes, this is terrible functionality. So
let's use the relative path like the rest of the system and be happy. We
will fallback to the old behavior just for fun.