### PR TITLE
fix: node_modules absolute entry point never getting found

### DIFF
--- a/lib/hook.template.raw
+++ b/lib/hook.template.raw
@@ -21,11 +21,15 @@ function getGhooksEntryPoint() {
 }
 
 function getNodeModulesAbsoluteEntryPoint() {
+  const _nodeModulesPath = path.resolve(__dirname, '../', '../', 'node_modules')
+
   try {
-    return path.resolve(__dirname, '../', '../', 'node_modules')
+    fs.statSync(_nodeModulesPath)
   } catch (e) {
     return '{{node_modules_path}}'
   }
+
+  return _nodeModulesPath
 }
 
 function getGhooksAbsoluteEntryPoint() {

--- a/test/hook.template.raw.test.js
+++ b/test/hook.template.raw.test.js
@@ -7,7 +7,15 @@ describe('hook.template.raw', function describeHookTemplateRaw() {
 
     beforeEach(() => {
       this.ghooks = sinon.stub()
-      proxyquire('../lib/hook.template.raw', {ghooks: this.ghooks})
+      const stub = {
+        ghooks: this.ghooks,
+        fs: {
+          statSync: () => {
+            return {isFile: () => true}
+          },
+        },
+      }
+      proxyquire('../lib/hook.template.raw', stub)
     })
 
     it('delegates the hook execution to ghooks', () => {
@@ -21,13 +29,21 @@ describe('hook.template.raw', function describeHookTemplateRaw() {
       this.throwException = true
       proxyquire('../lib/hook.template.raw', {
         ghooks,
-        path: {
-          resolve: () => {
+        fs: {
+          statSync: () => {
             if (this.throwException) {
               this.throwException = false
               throw new Error('path missing')
             }
-            return '{{node_modules_path}}'
+          }
+        },
+        path: {
+          resolve: () => {
+            if (!this.throwException) {
+              return '{{node_modules_path}}'
+            }
+
+            return ''
           },
         },
       })
@@ -51,8 +67,18 @@ describe('hook.template.raw', function describeHookTemplateRaw() {
 
     beforeEach(() => {
       const ghooksEntryPoint = path.resolve(__dirname, '../', '../', 'node_modules', 'ghooks')
+
       this.ghooks = sinon.stub()
-      proxyquire('../lib/hook.template.raw', {ghooks: null, [ghooksEntryPoint]: this.ghooks})
+      const stub = {
+        ghooks: null,
+        [ghooksEntryPoint]: this.ghooks,
+        fs: {
+          statSync: () => {
+            return {isFile: () => true}
+          },
+        },
+      }
+      proxyquire('../lib/hook.template.raw', stub)
     })
 
     it('delegates the hook execution to ghooks', () => {


### PR DESCRIPTION
According to the docs (https://nodejs.org/api/path.html) `path.resolve` only ever throws for type errors (if any of the arguments aren't a string), not if the path does not exist. For that we have to use `fs.stat`/`fs.statSync`.