### PR TITLE
feat: support more hooks by `git-hooks-list`

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ One of the last things you want is to raise the barrier to contributing to your 
 * pre-applypatch
 * post-applypatch
 * pre-commit
+* pre-merge-commit
 * prepare-commit-msg
 * commit-msg
 * post-commit
@@ -72,8 +73,13 @@ One of the last things you want is to raise the barrier to contributing to your 
 * update
 * post-receive
 * post-update
+* push-to-checkout
 * pre-auto-gc
 * post-rewrite
+* sendemail-validate
+* fsmonitor-watchman
+* p4-pre-submit
+* post-index-change
 
 ## Common Issues
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -1,27 +1,8 @@
 const fs = require('fs')
 const resolve = require('path').resolve
 const findup = require('findup')
+const hooks = require('git-hooks-list')
 const template = require('./hook.template')
-
-const hooks = [
-  'applypatch-msg',
-  'pre-applypatch',
-  'post-applypatch',
-  'pre-commit',
-  'prepare-commit-msg',
-  'commit-msg',
-  'post-commit',
-  'pre-rebase',
-  'post-checkout',
-  'post-merge',
-  'pre-push',
-  'pre-receive',
-  'update',
-  'post-receive',
-  'post-update',
-  'pre-auto-gc',
-  'post-rewrite',
-]
 
 function installHooks() {
   const gitRoot = findGitRoot()

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "findup": "0.1.5",
+    "git-hooks-list": "2.0.0",
     "lodash.clone": "4.5.0",
     "manage-path": "2.0.0",
     "opt-cli": "1.6.0",


### PR DESCRIPTION
`git-hooks-list` support all documented hooks, [`v2.0.0` include unreleased p4 submit hooks](https://github.com/fisker/git-hooks-list/pull/269) .

Fixes #221